### PR TITLE
Remove stray console.log call

### DIFF
--- a/YAFA.php
+++ b/YAFA.php
@@ -300,7 +300,6 @@ function yafa_footer_script() {
 						'style', 'background-image: url(' + yafa_img + ');' + yafa_style
 					);
 					jQuery('html').bind('mousemove', function(e) {
-						console.log(jQuery('#page-wrapper, #inner-wrapper, .page').is(e.target));
 						if( (jQuery('#page-wrapper, #inner-wrapper, .page').is(e.target)) && (yafa_linkheight == 0 || e.pageY <=yafa_linkheight ) ) {
 							jQuery('html').css({ 'cursor' :'pointer' });
 						} else {


### PR DESCRIPTION
I noticed when testing Mormont on VG that the console was still logging every single mouse movement, so I thought we should probably remove it.

To test, run a WP site with this plugin enabled and check that the mouse movement isn't being logged, and that the YAFA ads still work. You can test it here https://thomas-vg247-com.dev.gamer-network.net/
